### PR TITLE
Removed Meetalva - website is not reachable

### DIFF
--- a/src/design-tools.ts
+++ b/src/design-tools.ts
@@ -42,10 +42,6 @@ export const designTools = [{
   link: 'https://zeroheight.com',
   title: 'Zero Height',
 }, {
-  image: '/logos/logo-alva.svg',
-  link: 'https://meetalva.io',
-  title: 'Alva',
-}, {
   image: '/logos/logo-modulz.svg',
   link: 'https://www.modulz.app',
   title: 'Modulz',


### PR DESCRIPTION
Meetalva website/project is not active anymore.
<img width="1028" alt="Screenshot 2021-12-17 at 11 06 24 AM" src="https://user-images.githubusercontent.com/5433320/146494689-ff945dbe-6bbe-4c1c-8c28-a8f74faa5f0e.png">
